### PR TITLE
(#11) fixed empty metrics configuration bug for remote runs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Last Changes
 
+- [#11](https://github.com/aixigo/arestocats/issue/11): Fixed Promise rejection when metrics-plugin is not configured.
 - [#8](https://github.com/aixigo/arestocats/pull/8): Implemented metrics-plugin.
 
 ## v0.3.2

--- a/src/services/cli.js
+++ b/src/services/cli.js
@@ -83,7 +83,7 @@ module.exports = function( state, options = {} ) {
             .then( _ => _.json() )
             .then( metrics => {
                generateJSON( metrics, reporters.includes( 'html' ) );
-            } );
+            }, () => {} );
 
          return Promise.all( [ resultsPromise, metricsPromise ] )
             .then( ( [ results ] ) => {


### PR DESCRIPTION
The bug was an unhandled promise rejection for complete tests-runs without metrics. The fix was easy, because nothing needs to be done, when the response for the metric-request is empty.